### PR TITLE
Build fluidsynth variant with sf3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The original README is here: [README.original.md](./README.original.md)
 
 In order to build WebAssembly version of fluidsynth by yourself:
 ```shell
+# Optional step to include sf3 support
+./build_libsdnfile.sh
 # All variants of libfluidsynth-X.X.X.js + libfuluidsynth-X.X.X.wasm files will be stored to ./dist 
 ./build.sh
 ```

--- a/build.sh
+++ b/build.sh
@@ -62,12 +62,33 @@ compile_libfluidsynth() {
 rm -rf dist
 mkdir -p dist
 
-# Build RELEASE variants
-compile_libfluidsynth "" "-Denable-separate-wasm=on" "-s EXPORT_ES6=1" # ES6 + WASM
-compile_libfluidsynth "-all-in-one" "-Denable-separate-wasm=off" "-s EXPORT_ES6=1" # ES6 + INLINE WASM
+function compile_libfluidsynth_configurations () {
+  DEBUG=0
 
-# Build DEBUG variants
-DEBUG=1
+  # Build RELEASE variants
+  compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}" "-Denable-separate-wasm=on" "-s EXPORT_ES6=1" # ES6 + WASM
+  compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}-all-in-one" "-Denable-separate-wasm=off" "-s EXPORT_ES6=1" # ES6 + INLINE WASM
 
-compile_libfluidsynth "-debug" "-Denable-separate-wasm=on" "-s EXPORT_ES6=1" # ES6 + WASM
-compile_libfluidsynth "-all-in-one-debug" "-Denable-separate-wasm=off" "-s EXPORT_ES6=1" # ES6 + INLINE WASM
+  # temporary disable building of debug artifacts
+  return 0
+
+  compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}-debug" "-Denable-separate-wasm=on" "-s EXPORT_ES6=1" # ES6 + WASM
+  compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}-all-in-one-debug" "-Denable-separate-wasm=off" "-s EXPORT_ES6=1" # ES6 + INLINE WASM
+}
+
+# Configuration without sf3 support
+compile_libfluidsynth_configurations
+
+# Configuration with sf3 support though libsndfile addon
+LIBFLUIDSYNTH_DEPS_PKG_CONFIG_PATH=$(readlink -f ../libsndfile-emscripten/deps/lib/pkgconfig)
+
+if [ ! -d "$LIBFLUIDSYNTH_DEPS_PKG_CONFIG_PATH" ]; then
+    echo "Error: libsndfile artifacts directory '$LIBFLUIDSYNTH_DEPS_PKG_CONFIG_PATH' does not exist."
+    exit 1
+fi
+
+export PKG_CONFIG_PATH=${LIBFLUIDSYNTH_DEPS_PKG_CONFIG_PATH}
+
+LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX="-sf3"
+
+compile_libfluidsynth_configurations

--- a/build.sh
+++ b/build.sh
@@ -63,14 +63,13 @@ rm -rf dist
 mkdir -p dist
 
 function compile_libfluidsynth_configurations () {
-  DEBUG=0
+  unset DEBUG
 
   # Build RELEASE variants
   compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}" "-Denable-separate-wasm=on" "-s EXPORT_ES6=1" # ES6 + WASM
   compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}-all-in-one" "-Denable-separate-wasm=off" "-s EXPORT_ES6=1" # ES6 + INLINE WASM
 
-  # temporary disable building of debug artifacts
-  return 0
+  DEBUG=1
 
   compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}-debug" "-Denable-separate-wasm=on" "-s EXPORT_ES6=1" # ES6 + WASM
   compile_libfluidsynth "${LIBFLUIDSYNTH_OUTPUT_FILENAME_PREFIX}-all-in-one-debug" "-Denable-separate-wasm=off" "-s EXPORT_ES6=1" # ES6 + INLINE WASM

--- a/build_libsndfile.sh
+++ b/build_libsndfile.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TAG=0.0.1
+set -e
+cd ..
+wget https://github.com/enikey87/libsndfile-emscripten/archive/refs/tags/${TAG}.tar.gz -O libsndfile-emscripten.tar.gz
+tar xvf libsndfile-emscripten.tar.gz
+rm libsndfile-emscripten.tar.gz
+mv libsndfile-emscripten-${TAG} libsndfile-emscripten
+cd libsndfile-emscripten
+./deps.sh
+./build.sh


### PR DESCRIPTION
Fluidsynth SF3 support require libsndfile to be compiled with emscripten. libsndfile requires opus, vorbis, flac etc to be compiled with emscripten. Sad, but true.

I moved libsndfile emscripten snippets into [libsndfile-emscripten](https://github.com/enikey87/libsndfile-emscripten) repo and modified main build script to produce additional variant of libfluidsynth with SF3 support.
